### PR TITLE
Add debug option to launcher

### DIFF
--- a/exe/list_resolver
+++ b/exe/list_resolver
@@ -20,6 +20,8 @@ opts = Trollop.options do
       default: CATALOGUE_OF_LIFE)
   opt(:skip_original, "If given, only 'taxonID' is shown " \
       "from the original input", type: :boolean)
+  opt(:debug, "If given, prints statistics of name resolution to STDOUT",
+      short: "D", type: :boolean)
 end
 
 Trollop.die :input, "must be set" if opts[:input].nil?

--- a/lib/gn_list_resolver.rb
+++ b/lib/gn_list_resolver.rb
@@ -6,6 +6,7 @@ require "rest_client"
 require "tempfile"
 require "logger"
 require "logger/colors"
+require "pp"
 require "biodiversity"
 require "gn_uuid"
 require "graphql/client"
@@ -38,7 +39,7 @@ module GnListResolver
       writer = create_writer(reader, output_io, opts)
       resolver = create_resolver(writer, opts)
       block_given? ? resolver.resolve(data, &Proc.new) : resolver.resolve(data)
-      puts resolver.stats.stats if opts[:debug]
+      logger.warn(resolver.stats.stats.pretty_inspect) if opts[:debug]
       resolver.stats
     end
 


### PR DESCRIPTION
I'd like to have option to investigate stats.

Also `puts` in that context fails with exception:

```
/Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:162:in ``': closed stream (IOError)
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:162:in `block (2 levels) in git'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:239:in `block in capture_and_filter_stderr'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/2.4.0/tempfile.rb:295:in `open'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:237:in `capture_and_filter_stderr'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:162:in `block in git'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/shared_helpers.rb:73:in `with_clean_git_env'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:161:in `git'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/source/git/git_proxy.rb:89:in `full_version'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/env.rb:89:in `git_version'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/env.rb:22:in `report'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:95:in `request_issue_report_for'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:45:in `log_error'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:123:in `rescue in with_friendly_errors'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
	from /Users/home/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
	from /Users/home/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
	from /Users/home/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'
```